### PR TITLE
Improve linked issues detection

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -1,14 +1,14 @@
 # Edit these settings according to your needs
 
-# The Github user/organization that owns the repo 
 [conf]
+# The Github user/organization that owns the repo 
 user = rero
 # The name of the Github repo
 repo = rero-ils
 
 # A list of the Github labels to be ignored when generating the changelog
-ignore_labels = stale,duplicate,wontfix,translations,task
+ignore_labels = stale,duplicate,wontfix,task
 
-# The branch where 
+# The branch where
 new_release_branch = staging
 latest_release_branch = master


### PR DESCRIPTION
* Date comparison was inconsistent to detect
linked PRs. Use `issue.body` to detect keywords
* Improve click progress

Co-Authored-by: Pascal Repond <pascal.repond@rero.ch>